### PR TITLE
Switch despacho URL patterns to integer ids

### DIFF
--- a/gestion/urls.py
+++ b/gestion/urls.py
@@ -79,8 +79,8 @@ urlpatterns = [
 
     # Despachos de materiales
     path('despachos/', views.despachos, name='despachos'),
-    path('despacho/<uuid:id>/', views.detalle_despacho, name='detalle_despacho'),
-    path('despacho/detalle/eliminar/<uuid:id>/', views.eliminar_detalle_despacho, name='eliminar_detalle_despacho'),
+    path('despacho/<int:id>/', views.detalle_despacho, name='detalle_despacho'),
+    path('despacho/detalle/eliminar/<int:id>/', views.eliminar_detalle_despacho, name='eliminar_detalle_despacho'),
     
 
     


### PR DESCRIPTION
## Summary
- update dispatcher URLs to accept `int` ids

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683a6bda5d208323a3d954f6122cc81a